### PR TITLE
container_init: Add the log_driver to argument_spec

### DIFF
--- a/roles/container_init/meta/argument_specs.yml
+++ b/roles/container_init/meta/argument_specs.yml
@@ -68,3 +68,7 @@ argument_specs:
             type: "bool"
             default: true
             description: "Recreate the container when started by systemd."
+          log_driver:
+            type: "str"
+            default: "journald"
+            description: "Sets the log driver for the container. See --log-driver in podman-create(1)."


### PR DESCRIPTION
Add the log_driver argument to the argument_spec as it is already supported.